### PR TITLE
chore(buildpy): format with ruff

### DIFF
--- a/recipe/build.py
+++ b/recipe/build.py
@@ -1,35 +1,36 @@
 import os
 import platform
-from io import BytesIO
-from zipfile import ZipFile
-from urllib.request import urlopen
 import sys
+from io import BytesIO
+from urllib.request import urlopen
+from zipfile import ZipFile
 
 
 def _determine_filename():
-   print(f"Platform: {platform.uname()}")
+    print(f"Platform: {platform.uname()}")
 
-   if platform.uname().system == "Darwin":
-      return "darwin-universal.cli.package.zip"  
-   if platform.uname().system == "Windows":
-      return "windows-amd64.cli.package.zip"
-   return "linux-amd64.cli.package.zip"
+    if platform.uname().system == "Darwin":
+        return "darwin-universal.cli.package.zip"
+    if platform.uname().system == "Windows":
+        return "windows-amd64.cli.package.zip"
+    return "linux-amd64.cli.package.zip"
+
 
 def _files(zipfile):
-   if zipfile.startswith("windows"):
-       return ["dataformat.exe", "datasets.exe"]
-   return ["dataformat", "datasets"]
+    if zipfile.startswith("windows"):
+        return ["dataformat.exe", "datasets.exe"]
+    return ["dataformat", "datasets"]
 
 
 # Setup
-PREFIX=os.environ['PREFIX']
+PREFIX = os.environ["PREFIX"]
 
-BIN_DIR='{}/bin/'.format(PREFIX)
+BIN_DIR = "{}/bin/".format(PREFIX)
 if not os.path.exists(BIN_DIR):
     os.mkdir(BIN_DIR)
 
 if len(sys.argv) != 2:
-   raise Exception("Must pass one argument, the version string, to this script")
+    raise Exception("Must pass one argument, the version string, to this script")
 version = sys.argv[1]
 filename = _determine_filename()
 
@@ -41,10 +42,9 @@ myzip = ZipFile(BytesIO(resp.read()))
 
 
 for file in _files(filename):
-   output = f"{BIN_DIR}/{file}"
-   print(f"Writing {output}")
-   with open(output, "wb") as fh:
-      for line in myzip.open(file).readlines():
-         fh.write(line)
-   os.chmod(output, 0o755)
-
+    output = f"{BIN_DIR}/{file}"
+    print(f"Writing {output}")
+    with open(output, "wb") as fh:
+        for line in myzip.open(file).readlines():
+            fh.write(line)
+    os.chmod(output, 0o755)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7bfbdc1d2189c55f8f9216e17ffe6e8e46cc5dcb3d4c022e8bda0e4f426674b1
 
 build:
-  number: 0
+  number: 1
   script: python {{ RECIPE_DIR }}/build.py {{ version }}
 
 requirements:


### PR DESCRIPTION
The indent was 3 spaces, very confusing
I don't think I've ever seen 3 spaces used for indent, better use the canonical 4

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
